### PR TITLE
L'URL du feed NZBClub a changé

### DIFF
--- a/couchpotato/core/media/_base/providers/nzb/binnewz/nzbclub.py
+++ b/couchpotato/core/media/_base/providers/nzb/binnewz/nzbclub.py
@@ -12,7 +12,7 @@ log = CPLog(__name__)
 class NZBClub(NZBDownloader, NZBProvider, RSS):
     
     urls = {
-        'search': 'http://www.nzbclub.com/nzbfeeds.aspx?%s',
+        'search': 'https://www.nzbclub.com/nzbrss.aspx?%s',
     }
 
     http_time_between_calls = 4 #seconds


### PR DESCRIPTION
Et cela a pour conséquence de faire faire planter le parseur rendant le téléchargement via Binnews impossible
